### PR TITLE
Fixing Depends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,6 @@ Author: Max Corbin
 Maintainer: Max Corbin <max@looker.com>
 Description: LookRLite is a package, based on Scott Hoover's LookR, that contains functions that interface with Looker's API.
 License: GPL-2
-Depends: R (>=3.0.0)
+Depends: R (>= 3.0.0)
 Imports: httr, jsonlite
 NeedsCompilation: no


### PR DESCRIPTION
The depends line is currently unable to be parsed which makes devtools::install_github('maxcorbin/lookrlite') fail.