### PR TITLE
Login

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -10,9 +10,9 @@ CheckAlive <- function(hostname,
 }
 
 ApiLogin <- function(hostname,
-										 clientId,
-										 clientSecret,
-										 port = 19999) {
+					 clientId,
+					 clientSecret,
+					 port = 19999) {
 	
 	# Check the instance at hostname:port/alive to make sure it can response
 	if (!CheckAlive(hostname = hostname, 
@@ -39,16 +39,16 @@ ApiLogin <- function(hostname,
 	token <- jsonlite::fromJSON(content(requestResponse, as="text"))
 	
 	# Set connection in R session as a list in the global environment
-	SetConnection(hostname     = hostname,
-								port         = port,
-								clientId     = clientId,
-								clientSecret = clientSecret,
-								token        = token)
+	looker_conn <- SetConnection(hostname     = hostname,
+								port          = port,
+								clientId      = clientId,
+								clientSecret  = clientSecret,
+								token         = token)
 	
 	# Check the access token to make sure it looks as expected
 	if (!is.null(token["access_token"]) && nchar(token["access_token"]) == 40) {
 		message("Login success")
-		return(TRUE)
+		return(looker_conn)
 	}
 }
 
@@ -59,10 +59,10 @@ ApiLogout <- function(hostname,
 	
 	# Build a DELETE request, send to hostname:port/logout to revoke token
 	requestResponse <- ApiDelete(hostname = hostname,
-															 port = port,
-															 path = "logout",
-															 add_headers(Authentication = connection["token"]))
-	
+								 port = port,
+								 path = "logout",
+								 add_headers(Authentication = connection["token"]))
+
 	# Check response for success before returning
 	# TODO (maxcorbin): Try to send a simple API request using old token
 	# 									to make sure the token was revoked successfully

--- a/README.md
+++ b/README.md
@@ -3,4 +3,26 @@ LookR Lite is a package for accessing the Looker API through HTTP requests. It's
 
 This repository uses [Google's style guide for R](https://google.github.io/styleguide/Rguide.xml) for clarity in all R code!e
 
+# Basic Usage
+
+First login to create a token that you can authenticate with.
+
+```r
+looker_token <- ApiLogin('yourcompany.looker.com', 'your_id', 'your_secret')
+```
+
+Then you will be able to call the two functions currently implemented.
+
+run_look will retrieve the data from a look that already exists.
+
+```r
+look_data <- run_look(looker_token, look_id)
+```
+
+get_look will give you metadata about a look.
+
+```r
+look_metadata <- get_look(looker_token, look_id)
+```
+
 # More to come!


### PR DESCRIPTION
Before you had to manually find the token and ApiLogin just returned TRUE. Now you can assign ApiLogin to a variable that can be passed to the endpoint functions.

I added some rough documentations to the README.md so that people will know how to use the tool.